### PR TITLE
Split CI into build artifact stage and dependency-free testing stage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - name: Pack build artifact
+        run: |
+          tar -czf build-artifact.tar.gz dist package.json package-lock.json node_modules tests
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: build-artifact.tar.gz
+
+  testing:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+      - run: tar -xzf build-artifact.tar.gz
+      - name: Run artifact-based smoke test (no npm install)
+        run: node tests/smoke.mjs

--- a/README.md
+++ b/README.md
@@ -1,1 +1,107 @@
 # webcam-mvp
+
+Node.js(TypeScript)で実装した、WebRTC用のシンプルなシグナリングサーバです。
+
+## 要件
+
+- ライブラリ: `ws`
+- ポート: `3001`
+- room機能: `ws://host:3001?room=abc`
+- 同じroom内の他クライアントへブロードキャスト（送信元は除外）
+- メッセージ形式: JSON文字列 `{ type: "offer"|"answer"|"ice"|"hello", payload: any }`
+- 不正JSONや例外は握りつぶさずログ出力
+- 接続/切断/room人数をログ出力
+
+## セットアップ
+
+```bash
+npm install
+```
+
+## 起動
+
+### 開発モード
+
+```bash
+npm run dev
+```
+
+### ビルド
+
+```bash
+npm run build
+```
+
+### 本番起動（ビルド後）
+
+```bash
+npm run start
+```
+
+## テスト方針
+
+`npm install` ができない環境を想定し、CIを2段に分離しています。
+
+1. **build job**（依存取得が許可された環境）
+   - `npm ci`
+   - `npm run build`
+   - `dist/` と `node_modules/` をアーティファクト化
+2. **testing job**（依存取得なし）
+   - アーティファクトを展開
+   - `node tests/smoke.mjs` を実行
+
+これにより testing 側では依存取得不要で検証できます。
+
+## 手動テスト方法
+
+### 1) サーバ起動
+
+```bash
+npm run dev
+```
+
+### 2) WebSocketクライアントを2つ接続
+
+例: `wscat` を使う場合
+
+```bash
+npx wscat -c ws://localhost:3001?room=abc
+npx wscat -c ws://localhost:3001?room=abc
+```
+
+### 3) 片方のクライアントから送信
+
+```json
+{"type":"hello","payload":{"msg":"hi"}}
+```
+
+もう片方のクライアントだけが受信し、送信元には返らないことを確認します。
+
+### 4) 不正JSONの確認
+
+```text
+not-json
+```
+
+サーバ側にエラーログが出ることを確認します。
+
+### 5) 不正フォーマットJSONの確認
+
+```json
+{"type":"unknown","payload":{}}
+```
+
+サーバ側にフォーマットエラーログが出ることを確認します。
+
+## CI向けスモークテスト
+
+依存インストール済み成果物を前提に、以下で最小の疎通確認を行います。
+
+```bash
+node tests/smoke.mjs
+```
+
+検証内容:
+- 同一roomへは配信される
+- 送信元へは返らない
+- 別roomへは配信されない

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "webcam-mvp",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Simple WebRTC signaling server",
+  "main": "dist/server.js",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/server.js",
+    "test:smoke": "node tests/smoke.mjs"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/ws": "^8.5.13",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,114 @@
+import { WebSocketServer, WebSocket, RawData } from "ws";
+
+type MessageType = "offer" | "answer" | "ice" | "hello";
+
+interface SignalingMessage {
+  type: MessageType;
+  payload: unknown;
+}
+
+const PORT = 3001;
+
+const rooms = new Map<string, Set<WebSocket>>();
+const socketToRoom = new Map<WebSocket, string>();
+
+const wss = new WebSocketServer({ port: PORT });
+
+const getRoomIdFromUrl = (url?: string): string => {
+  if (!url) {
+    return "default";
+  }
+
+  try {
+    const parsed = new URL(url, `ws://localhost:${PORT}`);
+    return parsed.searchParams.get("room") || "default";
+  } catch (error) {
+    console.error("Failed to parse connection URL:", { url, error });
+    return "default";
+  }
+};
+
+const getRoomSize = (roomId: string): number => rooms.get(roomId)?.size ?? 0;
+
+const isValidSignalingMessage = (value: unknown): value is SignalingMessage => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const validTypes: MessageType[] = ["offer", "answer", "ice", "hello"];
+
+  return validTypes.includes(candidate.type as MessageType) && "payload" in candidate;
+};
+
+wss.on("connection", (socket, request) => {
+  const roomId = getRoomIdFromUrl(request.url);
+
+  if (!rooms.has(roomId)) {
+    rooms.set(roomId, new Set<WebSocket>());
+  }
+
+  rooms.get(roomId)?.add(socket);
+  socketToRoom.set(socket, roomId);
+
+  console.log(`Client connected. room=${roomId}, clients=${getRoomSize(roomId)}`);
+
+  socket.on("message", (data: RawData) => {
+    try {
+      const text = typeof data === "string" ? data : data.toString("utf-8");
+      const parsed: unknown = JSON.parse(text);
+
+      if (!isValidSignalingMessage(parsed)) {
+        console.error("Invalid signaling message format:", parsed);
+        return;
+      }
+
+      const peers = rooms.get(roomId);
+      if (!peers) {
+        return;
+      }
+
+      const message = JSON.stringify(parsed);
+      for (const peer of peers) {
+        if (peer !== socket && peer.readyState === WebSocket.OPEN) {
+          peer.send(message);
+        }
+      }
+    } catch (error) {
+      console.error("Failed to process incoming message:", {
+        roomId,
+        error,
+        rawData: data.toString()
+      });
+    }
+  });
+
+  socket.on("close", () => {
+    const targetRoom = socketToRoom.get(socket);
+    if (!targetRoom) {
+      return;
+    }
+
+    const peers = rooms.get(targetRoom);
+    peers?.delete(socket);
+    socketToRoom.delete(socket);
+
+    if (peers && peers.size === 0) {
+      rooms.delete(targetRoom);
+    }
+
+    console.log(`Client disconnected. room=${targetRoom}, clients=${getRoomSize(targetRoom)}`);
+  });
+
+  socket.on("error", (error) => {
+    console.error("Socket error:", { roomId, error });
+  });
+});
+
+wss.on("listening", () => {
+  console.log(`Signaling server started on ws://localhost:${PORT}`);
+});
+
+wss.on("error", (error) => {
+  console.error("WebSocket server error:", error);
+});

--- a/tests/smoke.mjs
+++ b/tests/smoke.mjs
@@ -1,0 +1,75 @@
+import { spawn } from 'node:child_process';
+import assert from 'node:assert/strict';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const connect = (url) =>
+  new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error(`Connection timeout: ${url}`));
+    }, 5000);
+
+    ws.onopen = () => {
+      clearTimeout(timer);
+      resolve(ws);
+    };
+    ws.onerror = (event) => {
+      clearTimeout(timer);
+      reject(new Error(`WebSocket error: ${event?.message ?? 'unknown'}`));
+    };
+  });
+
+const waitForMessage = (ws, timeoutMs = 3000) =>
+  new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('Message timeout')), timeoutMs);
+    ws.onmessage = (event) => {
+      clearTimeout(timer);
+      resolve(typeof event.data === 'string' ? event.data : String(event.data));
+    };
+  });
+
+const expectNoMessage = (ws, timeoutMs = 800) =>
+  new Promise((resolve, reject) => {
+    let gotMessage = false;
+    ws.onmessage = () => {
+      gotMessage = true;
+      reject(new Error('Unexpected message received'));
+    };
+    setTimeout(() => {
+      if (!gotMessage) {
+        resolve();
+      }
+    }, timeoutMs);
+  });
+
+const server = spawn('node', ['dist/server.js'], { stdio: ['ignore', 'pipe', 'pipe'] });
+
+server.stdout.on('data', (buf) => process.stdout.write(`[server] ${buf}`));
+server.stderr.on('data', (buf) => process.stderr.write(`[server:err] ${buf}`));
+
+try {
+  await wait(700);
+
+  const sender = await connect('ws://127.0.0.1:3001?room=abc');
+  const receiver = await connect('ws://127.0.0.1:3001?room=abc');
+  const otherRoom = await connect('ws://127.0.0.1:3001?room=xyz');
+
+  const payload = { type: 'hello', payload: { msg: 'hi' } };
+  sender.send(JSON.stringify(payload));
+
+  const received = await waitForMessage(receiver);
+  assert.deepEqual(JSON.parse(received), payload);
+
+  await expectNoMessage(sender);
+  await expectNoMessage(otherRoom);
+
+  sender.close();
+  receiver.close();
+  otherRoom.close();
+
+  console.log('Smoke test passed');
+} finally {
+  server.kill('SIGTERM');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
### Motivation
- Enable CI to run tests in environments where `npm install`/network access is restricted by separating dependency installation from testing.
- Provide an artifact-based smoke test that validates room-scoped WebSocket broadcast behavior without fetching dependencies in the testing stage.
- Make local and CI verification clearer and reproducible by documenting the two-stage approach in `README.md`.

### Description
- Added a two-stage GitHub Actions workflow `.github/workflows/ci.yml` that runs `npm ci` and `npm run build` in a `build` job and packages `dist/`, `node_modules/`, `tests/`, and package files into an artifact used by a `testing` job.
- Added an artifact-based smoke test `tests/smoke.mjs` that starts `dist/server.js`, opens three WebSocket clients, and asserts same-room delivery, no echo to sender, and no delivery to other rooms.
- Updated `package.json` to include the `test:smoke` script and kept existing scripts (`dev`, `build`, `start`) and dependencies; added `tests/smoke.mjs` to enable dependency-free execution of the smoke check.
- Updated `README.md` to document the two-stage CI strategy and how to run the smoke test locally or in CI without installing dependencies on the testing runner.

### Testing
- Ran `node --check tests/smoke.mjs` to validate the smoke test file syntax, and it succeeded.
- Verified repository status and committed the CI/test changes; `node --check dist/server.js` was not executed successfully here because `dist/` is not generated in this restricted environment (CI `build` job will produce it in an environment with network access).
- The CI workflow is designed so the `build` job runs `npm ci` and `npm run build` (where the full build will run) and the `testing` job runs `node tests/smoke.mjs` against the packaged artifact with no dependency fetching.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69968f4be624832e9458d00be8be1058)