### PR TITLE
Minimal Android WebRTC camera sender (Kotlin) with OkHttp signaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,108 @@
-# webcam-mvp
+# webcam-mvp (Android / Kotlin)
+
+WebRTC で **Android 端末のカメラ映像を送信**する最小構成アプリです。  
+受信側（viewer-web）が offer を作成する前提で、Android 側は `offer` 受信後に `answer` を返します。
+
+## 実装済み要件
+
+- UI
+  - Signaling URL 入力（`room` が無ければ room 入力値を自動付与）
+  - room 入力（デフォルト `abc`）
+  - Connect / Disconnect
+  - ローカルプレビュー `SurfaceViewRenderer`
+  - 状態表示 `iceConnectionState`
+- WebRTC
+  - `PeerConnectionFactory` 初期化（`EglBase`）
+  - `Camera2Enumerator` で `VideoCapturer` 作成（前面優先）
+  - `VideoSource -> VideoTrack` 作成
+  - ローカルプレビュー表示
+  - `PeerConnection` に `videoTrack` を `addTrack`
+  - `offer` 受信 -> `setRemoteDescription`
+  - `createAnswer` -> `setLocalDescription` -> `answer` 送信
+  - ICE candidate 送受信
+- Signaling
+  - OkHttp WebSocket
+  - JSON: `{type:"offer"|"answer"|"ice", payload:any}`
+- 権限
+  - `INTERNET`, `CAMERA`（`RECORD_AUDIO` 不要）
+
+## 使い方
+
+1. Android Studio でこのフォルダを開く
+2. Gradle Sync
+3. 実機で起動（カメラ利用のため実機推奨）
+4. Signaling URL と Room を入力して Connect
+
+### 入力例
+
+- URL に room を含む場合:  
+  `ws://192.168.0.5:3001?room=abc`
+- URL に room を含まない場合:  
+  `ws://192.168.0.5:3001` + room `abc`  
+  → 自動で `ws://192.168.0.5:3001?room=abc` にして接続
+
+## Signaling メッセージ形式
+
+### offer / answer
+
+```json
+{
+  "type": "offer",
+  "payload": {
+    "sdp": "...",
+    "type": "offer"
+  }
+}
+```
+
+```json
+{
+  "type": "answer",
+  "payload": {
+    "sdp": "...",
+    "type": "answer"
+  }
+}
+```
+
+### ice
+
+```json
+{
+  "type": "ice",
+  "payload": {
+    "candidate": "candidate:...",
+    "sdpMid": "0",
+    "sdpMLineIndex": 0
+  }
+}
+```
+
+## よくある落とし穴
+
+1. **localhost 問題**
+   - Android 実機から見た `localhost` は「実機自身」です。
+   - PC 上で signaling サーバーを動かしているなら、`ws://<PCのLAN IP>:3001` を使ってください。
+
+2. **Windows の IP 指定**
+   - `ipconfig` で IPv4 アドレスを確認し、Wi-Fi の同一ネットワーク上で接続します。
+   - 例: `ws://192.168.0.5:3001?room=abc`
+
+3. **ファイアウォール (FW)**
+   - Windows Defender Firewall などで `3001` ポート受信がブロックされると接続できません。
+   - signaling サーバーのポートを許可してください。
+
+4. **サーバー bind アドレス**
+   - サーバーが `127.0.0.1` bind だと他端末から接続不可です。
+   - `0.0.0.0` bind で起動してください。
+
+5. **Android のカメラ権限拒否**
+   - 初回権限ダイアログで拒否すると映像取得できません。
+   - 設定アプリから CAMERA を許可してください。
+
+## 主な構成ファイル
+
+- `app/src/main/java/com/example/webrtccamera/MainActivity.kt`
+- `app/src/main/res/layout/activity_main.xml`
+- `app/src/main/AndroidManifest.xml`
+- `app/build.gradle.kts`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,48 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.example.webrtccamera"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.webrtccamera"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.appcompat:appcompat:1.7.0")
+    implementation("com.google.android.material:material:1.12.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+
+    implementation("org.webrtc:google-webrtc:1.0.32006")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("org.json:json:20240303")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# No custom ProGuard rules for MVP.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.WebcamMvp">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/webrtccamera/MainActivity.kt
+++ b/app/src/main/java/com/example/webrtccamera/MainActivity.kt
@@ -1,0 +1,321 @@
+package com.example.webrtccamera
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.widget.Button
+import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.google.android.material.textfield.TextInputEditText
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import org.json.JSONObject
+import org.webrtc.Camera2Enumerator
+import org.webrtc.CandidatePairChangeEvent
+import org.webrtc.DefaultVideoDecoderFactory
+import org.webrtc.DefaultVideoEncoderFactory
+import org.webrtc.EglBase
+import org.webrtc.IceCandidate
+import org.webrtc.MediaConstraints
+import org.webrtc.PeerConnection
+import org.webrtc.PeerConnectionFactory
+import org.webrtc.SessionDescription
+import org.webrtc.SurfaceTextureHelper
+import org.webrtc.SurfaceViewRenderer
+import org.webrtc.VideoCapturer
+import org.webrtc.VideoSource
+import org.webrtc.VideoTrack
+
+class MainActivity : AppCompatActivity() {
+    private lateinit var signalingEditText: TextInputEditText
+    private lateinit var roomEditText: TextInputEditText
+    private lateinit var connectButton: Button
+    private lateinit var disconnectButton: Button
+    private lateinit var iceStateTextView: TextView
+    private lateinit var localRenderer: SurfaceViewRenderer
+
+    private var eglBase: EglBase? = null
+    private var peerConnectionFactory: PeerConnectionFactory? = null
+    private var peerConnection: PeerConnection? = null
+    private var videoCapturer: VideoCapturer? = null
+    private var videoSource: VideoSource? = null
+    private var localVideoTrack: VideoTrack? = null
+    private var surfaceTextureHelper: SurfaceTextureHelper? = null
+
+    private val okHttpClient = OkHttpClient()
+    private var webSocket: WebSocket? = null
+
+    private val cameraPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) {
+            connect()
+        } else {
+            iceStateTextView.text = "iceConnectionState: CAMERA permission denied"
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        signalingEditText = findViewById(R.id.signalingEditText)
+        roomEditText = findViewById(R.id.roomEditText)
+        connectButton = findViewById(R.id.connectButton)
+        disconnectButton = findViewById(R.id.disconnectButton)
+        iceStateTextView = findViewById(R.id.iceStateTextView)
+        localRenderer = findViewById(R.id.localRenderer)
+
+        connectButton.setOnClickListener {
+            ensureCameraPermissionAndConnect()
+        }
+        disconnectButton.setOnClickListener {
+            disconnect()
+        }
+    }
+
+    private fun ensureCameraPermissionAndConnect() {
+        val granted = ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) ==
+            PackageManager.PERMISSION_GRANTED
+        if (granted) {
+            connect()
+        } else {
+            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+    }
+
+    private fun initializeWebRtcIfNeeded() {
+        if (peerConnectionFactory != null) return
+
+        eglBase = EglBase.create()
+        localRenderer.init(eglBase!!.eglBaseContext, null)
+        localRenderer.setMirror(true)
+
+        val initOptions = PeerConnectionFactory.InitializationOptions.builder(this)
+            .createInitializationOptions()
+        PeerConnectionFactory.initialize(initOptions)
+
+        val encoderFactory = DefaultVideoEncoderFactory(eglBase!!.eglBaseContext, true, true)
+        val decoderFactory = DefaultVideoDecoderFactory(eglBase!!.eglBaseContext)
+
+        peerConnectionFactory = PeerConnectionFactory.builder()
+            .setVideoEncoderFactory(encoderFactory)
+            .setVideoDecoderFactory(decoderFactory)
+            .createPeerConnectionFactory()
+
+        videoCapturer = createVideoCapturer()
+        surfaceTextureHelper = SurfaceTextureHelper.create("CaptureThread", eglBase!!.eglBaseContext)
+        videoSource = peerConnectionFactory!!.createVideoSource(false)
+        videoCapturer?.initialize(
+            surfaceTextureHelper,
+            applicationContext,
+            videoSource?.capturerObserver
+        )
+        videoCapturer?.startCapture(1280, 720, 30)
+
+        localVideoTrack = peerConnectionFactory!!.createVideoTrack("localVideoTrack", videoSource)
+        localVideoTrack?.addSink(localRenderer)
+    }
+
+    private fun connect() {
+        initializeWebRtcIfNeeded()
+        createPeerConnection()
+
+        val signalingUrl = buildSignalingUrl(
+            signalingEditText.text?.toString().orEmpty(),
+            roomEditText.text?.toString().orEmpty().ifBlank { "abc" }
+        )
+
+        val request = Request.Builder().url(signalingUrl).build()
+        webSocket = okHttpClient.newWebSocket(request, object : WebSocketListener() {
+            override fun onOpen(webSocket: WebSocket, response: Response) {
+                runOnUiThread {
+                    iceStateTextView.text = "iceConnectionState: signaling connected"
+                }
+            }
+
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                handleSignalingMessage(text)
+            }
+
+            override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                runOnUiThread {
+                    iceStateTextView.text = "iceConnectionState: signaling closed"
+                }
+            }
+        })
+    }
+
+    private fun createPeerConnection() {
+        if (peerConnection != null) return
+
+        val iceServers = listOf(
+            PeerConnection.IceServer.builder("stun:stun.l.google.com:19302").createIceServer()
+        )
+
+        val rtcConfig = PeerConnection.RTCConfiguration(iceServers)
+        peerConnection = peerConnectionFactory?.createPeerConnection(rtcConfig, object : PeerConnection.Observer {
+            override fun onSignalingChange(newState: PeerConnection.SignalingState?) = Unit
+            override fun onIceConnectionChange(newState: PeerConnection.IceConnectionState?) {
+                runOnUiThread {
+                    iceStateTextView.text = "iceConnectionState: ${newState ?: "UNKNOWN"}"
+                }
+            }
+
+            override fun onIceConnectionReceivingChange(receiving: Boolean) = Unit
+            override fun onIceGatheringChange(newState: PeerConnection.IceGatheringState?) = Unit
+            override fun onIceCandidate(candidate: IceCandidate?) {
+                candidate ?: return
+                sendIceCandidate(candidate)
+            }
+
+            override fun onIceCandidatesRemoved(candidates: Array<out IceCandidate>?) = Unit
+            override fun onAddStream(stream: org.webrtc.MediaStream?) = Unit
+            override fun onRemoveStream(stream: org.webrtc.MediaStream?) = Unit
+            override fun onDataChannel(dataChannel: org.webrtc.DataChannel?) = Unit
+            override fun onRenegotiationNeeded() = Unit
+            override fun onAddTrack(receiver: org.webrtc.RtpReceiver?, mediaStreams: Array<out org.webrtc.MediaStream>?) = Unit
+            override fun onCandidatePairChanged(event: CandidatePairChangeEvent?) = Unit
+        })
+
+        localVideoTrack?.let {
+            peerConnection?.addTrack(it, listOf("localStream"))
+        }
+    }
+
+    private fun handleSignalingMessage(text: String) {
+        val root = JSONObject(text)
+        val type = root.optString("type")
+        val payload = root.optJSONObject("payload") ?: JSONObject()
+
+        when (type) {
+            "offer" -> handleOffer(payload)
+            "ice" -> handleRemoteIce(payload)
+        }
+    }
+
+    private fun handleOffer(payload: JSONObject) {
+        val sdp = payload.getString("sdp")
+        val remoteDescription = SessionDescription(SessionDescription.Type.OFFER, sdp)
+        peerConnection?.setRemoteDescription(SimpleSdpObserver(), remoteDescription)
+
+        peerConnection?.createAnswer(object : SimpleSdpObserver() {
+            override fun onCreateSuccess(sessionDescription: SessionDescription?) {
+                sessionDescription ?: return
+                peerConnection?.setLocalDescription(SimpleSdpObserver(), sessionDescription)
+                sendAnswer(sessionDescription)
+            }
+        }, MediaConstraints())
+    }
+
+    private fun handleRemoteIce(payload: JSONObject) {
+        val candidate = payload.optString("candidate", null) ?: return
+        val sdpMid = payload.optString("sdpMid", null)
+        val sdpMLineIndex = payload.optInt("sdpMLineIndex", -1)
+        if (sdpMLineIndex < 0) return
+        peerConnection?.addIceCandidate(IceCandidate(sdpMid, sdpMLineIndex, candidate))
+    }
+
+    private fun sendAnswer(sessionDescription: SessionDescription) {
+        val payload = JSONObject()
+            .put("sdp", sessionDescription.description)
+            .put("type", "answer")
+        val root = JSONObject()
+            .put("type", "answer")
+            .put("payload", payload)
+        webSocket?.send(root.toString())
+    }
+
+    private fun sendIceCandidate(candidate: IceCandidate) {
+        val payload = JSONObject()
+            .put("candidate", candidate.sdp)
+            .put("sdpMid", candidate.sdpMid)
+            .put("sdpMLineIndex", candidate.sdpMLineIndex)
+        val root = JSONObject()
+            .put("type", "ice")
+            .put("payload", payload)
+        webSocket?.send(root.toString())
+    }
+
+    private fun buildSignalingUrl(rawUrl: String, room: String): String {
+        if (rawUrl.isBlank()) return "ws://192.168.0.5:3001?room=$room"
+        return if (rawUrl.contains("room=")) {
+            rawUrl
+        } else {
+            val separator = if (rawUrl.contains("?")) "&" else "?"
+            "$rawUrl${separator}room=$room"
+        }
+    }
+
+    private fun disconnect() {
+        webSocket?.close(1000, "disconnect")
+        webSocket = null
+
+        peerConnection?.close()
+        peerConnection = null
+
+        videoCapturer?.stopCaptureSafely()
+        videoCapturer?.dispose()
+        videoCapturer = null
+
+        localVideoTrack?.dispose()
+        localVideoTrack = null
+
+        videoSource?.dispose()
+        videoSource = null
+
+        surfaceTextureHelper?.dispose()
+        surfaceTextureHelper = null
+
+        peerConnectionFactory?.dispose()
+        peerConnectionFactory = null
+
+        localRenderer.release()
+        eglBase?.release()
+        eglBase = null
+
+        runOnUiThread {
+            iceStateTextView.text = "iceConnectionState: disconnected"
+        }
+    }
+
+    override fun onDestroy() {
+        disconnect()
+        okHttpClient.dispatcher.executorService.shutdown()
+        super.onDestroy()
+    }
+
+    private fun createVideoCapturer(): VideoCapturer? {
+        val enumerator = Camera2Enumerator(this)
+        val deviceNames = enumerator.deviceNames
+
+        deviceNames.firstOrNull { enumerator.isFrontFacing(it) }?.let { frontCamera ->
+            enumerator.createCapturer(frontCamera, null)?.let { return it }
+        }
+
+        deviceNames.firstOrNull()?.let { fallback ->
+            enumerator.createCapturer(fallback, null)?.let { return it }
+        }
+
+        return null
+    }
+}
+
+private fun VideoCapturer.stopCaptureSafely() {
+    try {
+        stopCapture()
+    } catch (_: InterruptedException) {
+    }
+}
+
+open class SimpleSdpObserver : org.webrtc.SdpObserver {
+    override fun onCreateSuccess(sessionDescription: SessionDescription?) = Unit
+    override fun onSetSuccess() = Unit
+    override fun onCreateFailure(error: String?) = Unit
+    override fun onSetFailure(error: String?) = Unit
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="12dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/signalingLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/signalingEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_signaling_url"
+            android:inputType="textUri" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/roomLayout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/signalingLayout">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/roomEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/hint_room"
+            android:text="abc" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <LinearLayout
+        android:id="@+id/buttonRow"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="end"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/roomLayout">
+
+        <Button
+            android:id="@+id/connectButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/connect" />
+
+        <Button
+            android:id="@+id/disconnectButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:text="@string/disconnect" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/iceStateTextView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/ice_state"
+        app:layout_constraintTop_toBottomOf="@id/buttonRow"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <org.webrtc.SurfaceViewRenderer
+        android:id="@+id/localRenderer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="8dp"
+        android:background="#111111"
+        app:layout_constraintTop_toBottomOf="@id/iceStateTextView"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<resources>
+    <string name="app_name">WebRTC Camera Sender</string>
+    <string name="hint_signaling_url">Signaling URL (ws://192.168.0.5:3001?room=abc)</string>
+    <string name="hint_room">Room</string>
+    <string name="connect">Connect</string>
+    <string name="disconnect">Disconnect</string>
+    <string name="ice_state">iceConnectionState: NEW</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.WebcamMvp" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@android:color/holo_blue_dark</item>
+        <item name="colorPrimaryVariant">@android:color/holo_blue_light</item>
+        <item name="colorOnPrimary">@android:color/white</item>
+        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+    </style>
+</resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.5.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "WebcamMvp"
+include(":app")


### PR DESCRIPTION
### Motivation

- Provide a minimal Android Studio Kotlin app that sends camera video over WebRTC and answers an incoming `offer` from a web viewer. 
- Include a simple signaling client, local preview, and clear UI to quickly test camera send scenarios on a real device.

### Description

- Added Android project files and Gradle configuration (`build.gradle.kts`, `settings.gradle.kts`, `gradle.properties`) and an `app` module with dependencies for `google-webrtc`, OkHttp, and Material components. 
- Implemented `MainActivity.kt` which initializes `PeerConnectionFactory` with `EglBase`, creates a `VideoCapturer` via `Camera2Enumerator` (front camera prioritized), creates `VideoSource`/`VideoTrack`, attaches it to a `SurfaceViewRenderer`, and adds the track to the `PeerConnection`. 
- Implemented signaling over OkHttp WebSocket with JSON messages `{type:"offer"|"answer"|"ice", payload:any}`, handling `offer` → `setRemoteDescription` → `createAnswer` → `setLocalDescription` → send `answer`, and both local/remote ICE candidate exchange. 
- Added UI (`activity_main.xml`) with signaling URL input, room input (default `abc` and auto-appends `room` query param when missing), Connect/Disconnect buttons, `SurfaceViewRenderer` local preview, `iceConnectionState` display, app strings, theme, `AndroidManifest` permissions (`INTERNET`, `CAMERA`), and a README describing usage and common networking pitfalls. 

### Testing

- Ran `git status --short` to verify files were staged and present, which completed successfully. 
- Attempted `./gradlew :app:assembleDebug` but it failed because the Gradle wrapper (`./gradlew`) is not present in the repository, so a local build was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699699786e14832eaa43b13ea8e2ded6)